### PR TITLE
Fixed parts list scrolling issue. Added CTRL+SPACE shortcut to open parts list

### DIFF
--- a/src/main.gd
+++ b/src/main.gd
@@ -156,6 +156,9 @@ func _unhandled_key_input(event: InputEvent):
 			KEY_P:
 				if event.ctrl_pressed:
 					_on_add_part_button_pressed()
+			KEY_SPACE:
+				if event.ctrl_pressed:
+					_on_add_part_button_pressed()
 			KEY_T:
 				if event.ctrl_pressed:
 					%ToolsButton.get_popup().show()

--- a/src/scenes/help_tabs.tscn
+++ b/src/scenes/help_tabs.tscn
@@ -106,7 +106,7 @@ Ctrl + S - Save the circuit or open the SaveAs popup panel
 
 Ctrl + O or Ctrl + L - Open the panel for Loading circuits
 
-Ctrl + P - open the Part selection panel
+Ctrl + P / Ctrl + Space - open the Part selection panel
 
 Ctrl + T - open the Tool menu
 

--- a/src/scenes/part_list.gd
+++ b/src/scenes/part_list.gd
@@ -36,6 +36,11 @@ func update_block_list():
 
 
 func _on_list_item_clicked(index, _at_position, mouse_button_index, column_index):
+	# Only accept left and right mouse button clicks. 
+	# Don't react to scroll (button) - number 4
+	if mouse_button_index != 1 and mouse_button_index != 2:
+		return
+	
 	get_parent().hide()
 	var list = $HB.get_child(column_index).get_child(1)
 	list.deselect(index)
@@ -49,9 +54,3 @@ func _on_list_item_clicked(index, _at_position, mouse_button_index, column_index
 			# Delete block entry
 			G.settings.blocks.erase(list.get_item_text(index))
 			list.remove_item(index)
-
-
-func _on_item_list_gui_input(event):
-	# Prevent scroll wheel of mouse from causing window to close
-	if event is InputEventMouseButton and event.button_index > 1:
-		get_viewport().set_input_as_handled()

--- a/src/scenes/part_list.tscn
+++ b/src/scenes/part_list.tscn
@@ -69,8 +69,3 @@ text = "Blocks"
 clip_contents = false
 layout_mode = 2
 size_flags_vertical = 3
-
-[connection signal="gui_input" from="HB/VB1/ItemList" to="." method="_on_item_list_gui_input"]
-[connection signal="gui_input" from="HB/VB2/ItemList" to="." method="_on_item_list_gui_input"]
-[connection signal="gui_input" from="HB/VB3/ItemList" to="." method="_on_item_list_gui_input"]
-[connection signal="gui_input" from="HB/VB4/ItemList" to="." method="_on_item_list_gui_input"]


### PR DESCRIPTION
This PR adds two (in my opinion) improvements:
* Added additional parts list shortcut (Ctrl+Space) in addition to the original one (Ctrl+P). This change makes opening parts list with one hand possible and massively improves workflow speed (because opening parts list is one of the most used actions).
* Fixed scrolling the parts list. Previously scrolling had to be done by dragging a scrollbar instead of a mouse scroll. Now it works also with a mouse scroll without closing a parts list window.